### PR TITLE
add item trader to items

### DIFF
--- a/data/locales/de/common.js
+++ b/data/locales/de/common.js
@@ -18,6 +18,7 @@ module.exports = {
     onlyFavourites: "Meine Favoriten",
   },
   target: "Beeinflusst",
+  trader: "Händler",
   comingSoon: "Demnächst...",
   index: {
     intro:

--- a/data/locales/en/common.js
+++ b/data/locales/en/common.js
@@ -18,6 +18,7 @@ module.exports = {
     onlyFavourites: "My Favourites",
   },
   target: "Targets",
+  trader: "Trader",
   comingSoon: "Coming soon...",
   index: {
     intro:

--- a/src/components/ItemEffects.tsx
+++ b/src/components/ItemEffects.tsx
@@ -104,6 +104,10 @@ const ItemEffects = ({ item }: { item: AnnoItem }) => {
             <br />
           </span>
         ))}
+        <strong>{t("trader")}: </strong>
+        <span>
+        {item.trader.join(", ")}
+        </span>
       </Typography>
     </>
   );

--- a/src/data/AnnoItem.ts
+++ b/src/data/AnnoItem.ts
@@ -27,4 +27,5 @@ export interface AnnoItem {
   expeditionAttributes: ExpeditionAttribute[];
   upgrades: Upgrade[];
   favourite?: boolean;
+  trader: Array<string>;
 }

--- a/src/data/AnnoItemFactory.ts
+++ b/src/data/AnnoItemFactory.ts
@@ -5,15 +5,24 @@ export default class AnnoItemFactory {
   private translations: { [key: number]: string };
   private effectTargetPoolById: { [key: number]: any };
   private rewardPoolById: { [key: number]: any };
+  private traderProfiles: { [key: number]: any };
+  private rewardItemPools: { [key: number]: any };
+
+  private traderItems: { [key: number]: any };
 
   constructor(
     translations: { [key: number]: string },
     effectTargetPoolById: { [key: number]: any },
-    rewardPoolById: { [key: number]: any }
+    rewardPoolById: { [key: number]: any },
+    traderProfiles: Array<any>,
+    rewardItemPools: { [key: number]: any }
   ) {
     this.translations = translations;
     this.effectTargetPoolById = effectTargetPoolById;
     this.rewardPoolById = rewardPoolById;
+    this.traderProfiles = traderProfiles;
+    this.rewardItemPools = rewardItemPools;
+    this.traderItems = this.resolveTraderItems();
   }
 
   public newAnnoItem(asset: any): AnnoItem {
@@ -45,6 +54,7 @@ export default class AnnoItemFactory {
           rarities.find((r) => r.key === rarity)?.labelId as number
         ],
       upgrades: this.getUpgrades(values),
+      trader: this.resolveTrader(values)
     };
   }
 
@@ -89,6 +99,72 @@ export default class AnnoItemFactory {
         ];
       })
       .filter((target: EffectTarget) => target.label);
+  }
+
+
+private resolveTrader(values: any) {
+  let o:Array<any> = []
+  Object.entries(this.traderItems).forEach(keyval => {
+    if(keyval[1].includes(values.Standard.GUID)){
+      o.push(keyval[0])
+    }
+  })
+  return o
+}
+  
+  private resolveTraderItems():{ [key: string]: any } {
+    let o:{ [key: string]: Array<number> } = {}
+    this.traderProfiles.forEach((profile: {[key:string]: any}) => {
+      try{
+        //console.log(profile.Values.Standard.Name)
+        let rewardItemPoolGuid = profile.Values.Trader.Progression.EarlyGame.OfferingItems
+        if(rewardItemPoolGuid != undefined){
+          let rewardItemPoolGuids = this.rewardItemPools[rewardItemPoolGuid].Values.RewardPool.ItemsPool.Item.map((i: {[key:string]: number}) => {return i.ItemLink})
+  
+          let rewardPoolGuids = rewardItemPoolGuids.map((rig: any) => {
+            // some guids are rewardpool and not rewarditempool guids
+            if(Object.keys(this.rewardItemPools).includes(`${rig}`)){
+              if(this.rewardItemPools[rig].Values.RewardPool != ""){
+                // extract one/multiple rewardpool guid from rewarditempool 
+                if(Array.isArray(this.rewardItemPools[rig].Values.RewardPool.ItemsPool.Item)){
+                  let o = this.rewardItemPools[rig].Values.RewardPool.ItemsPool.Item.map((i: {[key:string]: number}) => {return i.ItemLink})
+                  return o
+                }else{
+                   return this.rewardItemPools[rig].Values.RewardPool.ItemsPool.Item.ItemLink
+                }
+              }
+            }else{
+              return rig
+            }
+          })
+          .filter((a: undefined) => a != undefined)
+          .flat()
+  
+          let itemGuids = rewardPoolGuids.map((rg: any) => {
+            if(Object.keys(this.rewardPoolById).includes(`${rg}`)){
+              if(this.rewardPoolById[rg].Values.RewardPool != ""){
+                // extract one/multiple rewardpool guid from rewarditempool 
+                if(Array.isArray(this.rewardPoolById[rg].Values.RewardPool.ItemsPool.Item)){
+                  let o = this.rewardPoolById[rg].Values.RewardPool.ItemsPool.Item.map((i: {[key:string]: number}) => {return i.ItemLink})
+                  return o
+                }else{
+                   return this.rewardPoolById[rg].Values.RewardPool.ItemsPool.Item.ItemLink
+                }
+              }
+            }else{
+              return rg
+            }
+          })
+          .filter((a: number) => a != undefined)
+          .flat()
+          let name = profile.Values.Standard.Name.split("(")[1].replace(")","")
+          o[name] = itemGuids
+        }
+      }catch(e){
+        //console.log(e.toString())
+      }
+    });
+    return o
   }
 
   private resolveExpeditionAttributes(values: any) {

--- a/src/data/fill-db.ts
+++ b/src/data/fill-db.ts
@@ -6,7 +6,7 @@ import AnnoItemFactory from "./AnnoItemFactory";
 async function main() {
   for (const language of languages) {
     await generateDBForLanguage(language.fileName);
-  }
+  }  
 }
 
 async function generateDBForLanguage(language: string) {
@@ -27,6 +27,10 @@ export async function getData(
   const translations = await loadTranslations(language);
   const rewardPoolById = await loadRewardPools();
   const effectTargetPoolById = await loadEffectTargetPools();
+
+  const traderProfiles = await readFromCache("assets", "profile_3rdparty");
+  const rewardItemPools = await loadRewardItemPools()
+
   const assets = (
     await Promise.all(
       fileNames.map((fileName) => readFromCache("assets", fileName))
@@ -36,7 +40,9 @@ export async function getData(
   const factory = new AnnoItemFactory(
     translations,
     effectTargetPoolById,
-    rewardPoolById
+    rewardPoolById,
+    traderProfiles,
+    rewardItemPools
   );
 
   return assets.filter(filter).map((asset: any) => factory.newAnnoItem(asset));
@@ -58,6 +64,17 @@ async function loadRewardPools() {
   return rewardPoolById;
 }
 
+async function loadRewardItemPools() {
+  const rewardItemPools = await readFromCache("assets", "rewarditempool");
+
+  const rewardItemPoolById: { [key: number]: any } = {};
+
+  for (const rewardItemPool of rewardItemPools) {
+    rewardItemPoolById[rewardItemPool.Values.Standard.GUID] = rewardItemPool;
+  }
+
+  return rewardItemPoolById;
+}
 async function loadEffectTargetPools() {
   const effectTargetPools = await readFromCache(
     "assets",


### PR DESCRIPTION
AnnoItemFactory map once all item GUID to each Trader.

When an item gets created it adds traders which sells the item to to item.

[AnnoItemFactory::resolveTraderItems()](https://github.com/Oskar1504/anno-toolkit/blob/07ef54b554e71268d0919fe8917d62a2850de751/src/data/AnnoItemFactory.ts#L115)

can be improved
